### PR TITLE
fix(net): Hide unix domain socket option on Windows

### DIFF
--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -45,6 +45,7 @@ where
     S: Into<String> + Send,
 {
     HostPort(S, u16),
+    #[cfg(unix)]
     UnixDomainSocket(S),
 }
 
@@ -147,6 +148,7 @@ where
 
                 Ok(endpoint.connect_lazy())
             }
+            #[cfg(unix)]
             CerbosEndpoint::UnixDomainSocket(path) => {
                 let mut endpoint = Channel::from_static("https://127.0.0.1:3593")
                     .connect_timeout(self.timeout)


### PR DESCRIPTION
Fixes https://github.com/cerbos/cerbos-sdk-rust/issues/62